### PR TITLE
Bug fix Dynamic Dataset

### DIFF
--- a/util_functions.py
+++ b/util_functions.py
@@ -132,7 +132,7 @@ class MyDynamicDataset(Dataset):
             self.links = (links[0][perm], links[1][perm])
             self.labels = labels[perm]
 
-    def __len__(self):
+    def len(self):
         return len(self.links[0])
 
     def get(self, idx):


### PR DESCRIPTION
For the pytorch geometric dataset, the abstract method is called len() and not __len__(), hence throws an error "TypeError: Can't instantiate abstract class MyDynamicDataset with abstract method len". This fixes it.